### PR TITLE
canrunner: Set cyclic transmission on RunMessageTransmitter init

### DIFF
--- a/pkg/canrunner/run_test.go
+++ b/pkg/canrunner/run_test.go
@@ -91,6 +91,10 @@ func TestRunMessageTransmitter_TransmitEventMessage(t *testing.T) {
 	g.Go(func() error {
 		return canrunner.RunMessageTransmitter(ctx, tx, node, msg, clock)
 	})
+	// then message should be queried for if it has cyclic transmission enabled
+	node.EXPECT().Lock()
+	msg.EXPECT().IsCyclicTransmissionEnabled()
+	node.EXPECT().Unlock()
 	// then the node should be locked
 	node.EXPECT().Lock()
 	// and the time should be queried


### PR DESCRIPTION
Check before starting the transmit loop if cyclic transmission has already been requested and enable it if so.