### PR TITLE
value description lint

### DIFF
--- a/internal/identifiers/case.go
+++ b/internal/identifiers/case.go
@@ -3,10 +3,15 @@ package identifiers
 import "unicode"
 
 func IsCamelCase(s string) bool {
-	for i, r := range s {
+	i := 0
+	for _, r := range s {
+		if unicode.IsDigit(r) {
+			continue
+		}
 		if i == 0 && !unicode.IsUpper(r) || !IsAlphaChar(r) && !IsNumChar(r) {
 			return false
 		}
+		i++
 	}
 	return true
 }

--- a/internal/identifiers/case_test.go
+++ b/internal/identifiers/case_test.go
@@ -10,7 +10,9 @@ func TestIsCamelCase(t *testing.T) {
 	assert.Assert(t, IsCamelCase("SOC"))
 	assert.Assert(t, IsCamelCase("Camel"))
 	assert.Assert(t, IsCamelCase("CamelCase"))
+	assert.Assert(t, IsCamelCase("111CamelCaseNr"))
 	assert.Assert(t, !IsCamelCase("camelCase"))
 	assert.Assert(t, !IsCamelCase("snake_case"))
 	assert.Assert(t, !IsCamelCase("kebab-case"))
+	assert.Assert(t, !IsCamelCase("111camelCaseNr"))
 }

--- a/pkg/dbc/analysis/passes/valuedescriptions/analyzer.go
+++ b/pkg/dbc/analysis/passes/valuedescriptions/analyzer.go
@@ -1,6 +1,8 @@
 package valuedescriptions
 
 import (
+	"fmt"
+
 	"go.einride.tech/can/internal/identifiers"
 	"go.einride.tech/can/pkg/dbc"
 	"go.einride.tech/can/pkg/dbc/analysis"
@@ -28,7 +30,12 @@ func run(pass *analysis.Pass) error {
 		for _, vd := range valueDescriptions {
 			vd := vd
 			if !identifiers.IsCamelCase(vd.Description) {
-				pass.Reportf(vd.Pos, "value description must be CamelCase")
+				// Descriptor has format "<value> <quote><description>"
+				//
+				// So we increase the column position by the size of value + 2 (space and quotes) so the lint
+				// error marker is on the description and not on the value
+				vd.Pos.Column += len(fmt.Sprintf("%d", int64(vd.Value))) + 2
+				pass.Reportf(vd.Pos, "value description must be CamelCase (numbers ignored)")
 			}
 		}
 	}

--- a/pkg/dbc/analysis/passes/valuedescriptions/analyzer_test.go
+++ b/pkg/dbc/analysis/passes/valuedescriptions/analyzer_test.go
@@ -14,14 +14,27 @@ func TestAnalyzer(t *testing.T) {
 			Name: "ok",
 			Data: `VAL_ 100 Command 2 "Reboot" 1 "Sync" 0 "Noop";`,
 		},
-
+		{
+			Name: "ok",
+			Data: `VAL_ 100 Command 2 "11Reboot" 1 "123" 0 "Noop";`,
+		},
 		{
 			Name: "underscore",
 			Data: `VAL_ 100 Command 2 "Reboot_Command" 1 "Sync" 0 "Noop";`,
 			Diagnostics: []*analysis.Diagnostic{
 				{
-					Pos:     scanner.Position{Line: 1, Column: 18},
-					Message: "value description must be CamelCase",
+					Pos:     scanner.Position{Line: 1, Column: 21},
+					Message: "value description must be CamelCase (numbers ignored)",
+				},
+			},
+		},
+		{
+			Name: "several digits value",
+			Data: `VAL_ 100 Command 234 "Reboot_Command" 1 "Sync" 0 "Noop";`,
+			Diagnostics: []*analysis.Diagnostic{
+				{
+					Pos:     scanner.Position{Line: 1, Column: 23},
+					Message: "value description must be CamelCase (numbers ignored)",
 				},
 			},
 		},


### PR DESCRIPTION
2 small changes

* Allow the description field of a value descriptor to start with numbers (but still required the first letter after the numbers to be upper case)
* Change the lint marker for when linting value descriptors to point to the description rather than the value
