### PR TITLE
fix: generate - handle enum descriptions with spaces

### DIFF
--- a/internal/generate/compile_test.go
+++ b/internal/generate/compile_test.go
@@ -64,6 +64,7 @@ func TestCompile_ExampleDBC(t *testing.T) {
 							{Value: 0, Description: "None"},
 							{Value: 1, Description: "Sync"},
 							{Value: 2, Description: "Reboot"},
+							{Value: 3, Description: "Headlights On"},
 						},
 					},
 				},

--- a/internal/generate/file.go
+++ b/internal/generate/file.go
@@ -6,6 +6,7 @@ import (
 	"go/format"
 	"go/types"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/shurcooL/go-goon"
@@ -121,6 +122,12 @@ func Imports(f *File) {
 	f.P("// Generated code. DO NOT EDIT.")
 }
 
+var nonAlphaNumericRegexp = regexp.MustCompile("[^a-zA-Z0-9]+")
+
+func slugifyString(s string) string {
+	return nonAlphaNumericRegexp.ReplaceAllString(s, "")
+}
+
 func SignalCustomType(f *File, m *descriptor.Message, s *descriptor.Signal) {
 	f.P("// ", signalType(m, s), " models the ", s.Name, " signal of the ", m.Name, " message.")
 	f.P("type ", signalType(m, s), " ", signalPrimitiveType(s))
@@ -128,13 +135,14 @@ func SignalCustomType(f *File, m *descriptor.Message, s *descriptor.Signal) {
 	f.P("// Value descriptions for the ", s.Name, " signal of the ", m.Name, " message.")
 	f.P("const (")
 	for _, vd := range s.ValueDescriptions {
+		desc := slugifyString(vd.Description)
 		switch {
 		case s.Length == 1 && vd.Value == 1:
-			f.P(signalType(m, s), "_", vd.Description, " ", signalType(m, s), " = true")
+			f.P(signalType(m, s), "_", desc, " ", signalType(m, s), " = true")
 		case s.Length == 1 && vd.Value == 0:
-			f.P(signalType(m, s), "_", vd.Description, " ", signalType(m, s), " = false")
+			f.P(signalType(m, s), "_", desc, " ", signalType(m, s), " = false")
 		default:
-			f.P(signalType(m, s), "_", vd.Description, " ", signalType(m, s), " = ", vd.Value)
+			f.P(signalType(m, s), "_", desc, " ", signalType(m, s), " = ", vd.Value)
 		}
 	}
 	f.P(")")

--- a/testdata/dbc/example/example.dbc
+++ b/testdata/dbc/example/example.dbc
@@ -73,7 +73,7 @@ BA_ "FieldType" SG_ 100 Command "Command";
 BA_ "FieldType" SG_ 500 TestEnum "TestEnum";
 BA_ "GenSigStartValue" SG_ 500 TestEnum 2;
 
-VAL_ 100 Command 2 "Reboot" 1 "Sync" 0 "None" ;
+VAL_ 100 Command 3 "Headlights On" 2 "Reboot" 1 "Sync" 0 "None" ;
 VAL_ 500 TestEnum 2 "Two" 1 "One" ;
 VAL_ 500 TestScaledEnum 3 "Six" 2 "Four" 1 "Two" 0 "Zero" ;
 VAL_ 500 TestBoolEnum 1 "One" 0 "Zero" ;

--- a/testdata/dbc/example/example.dbc.golden
+++ b/testdata/dbc/example/example.dbc.golden
@@ -817,19 +817,24 @@
   MessageID: (dbc.MessageID) 100,
   SignalName: (dbc.Identifier) (len=7) "Command",
   EnvironmentVariableName: (dbc.Identifier) "",
-  ValueDescriptions: ([]dbc.ValueDescriptionDef) (len=3) {
+  ValueDescriptions: ([]dbc.ValueDescriptionDef) (len=4) {
    (dbc.ValueDescriptionDef) {
     Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:76:18,
+    Value: (float64) 3,
+    Description: (string) (len=13) "Headlights On"
+   },
+   (dbc.ValueDescriptionDef) {
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:76:36,
     Value: (float64) 2,
     Description: (string) (len=6) "Reboot"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:76:29,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:76:47,
     Value: (float64) 1,
     Description: (string) (len=4) "Sync"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:76:38,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:76:56,
     Value: (float64) 0,
     Description: (string) (len=4) "None"
    }

--- a/testdata/gen/go/example/example.dbc.go
+++ b/testdata/gen/go/example/example.dbc.go
@@ -163,9 +163,10 @@ type DriverHeartbeat_Command uint8
 
 // Value descriptions for the Command signal of the DriverHeartbeat message.
 const (
-	DriverHeartbeat_Command_None   DriverHeartbeat_Command = 0
-	DriverHeartbeat_Command_Sync   DriverHeartbeat_Command = 1
-	DriverHeartbeat_Command_Reboot DriverHeartbeat_Command = 2
+	DriverHeartbeat_Command_None         DriverHeartbeat_Command = 0
+	DriverHeartbeat_Command_Sync         DriverHeartbeat_Command = 1
+	DriverHeartbeat_Command_Reboot       DriverHeartbeat_Command = 2
+	DriverHeartbeat_Command_HeadlightsOn DriverHeartbeat_Command = 3
 )
 
 func (v DriverHeartbeat_Command) String() string {
@@ -176,6 +177,8 @@ func (v DriverHeartbeat_Command) String() string {
 		return "Sync"
 	case 2:
 		return "Reboot"
+	case 3:
+		return "Headlights On"
 	default:
 		return fmt.Sprintf("DriverHeartbeat_Command(%d)", v)
 	}
@@ -2492,6 +2495,10 @@ var d = (*descriptor.Database)(&descriptor.Database{
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
 							Value:       (int)(2),
 							Description: (string)("Reboot"),
+						}),
+						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
+							Value:       (int)(3),
+							Description: (string)("Headlights On"),
 						}),
 					}),
 					ReceiverNodes: ([]string)([]string{


### PR DESCRIPTION
This replaces non-alphanumeric characters in descriptions with _ when generating the Go enums.

Fixes #30 