### PR TITLE
feat(descriptor): use int64 to represent value descriptor values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.16
+          go-version: 1.16
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/internal/generate/compile.go
+++ b/internal/generate/compile.go
@@ -143,7 +143,7 @@ func (c *compiler) addMetadata() {
 			for _, valueDescription := range def.ValueDescriptions {
 				signal.ValueDescriptions = append(signal.ValueDescriptions, &descriptor.ValueDescription{
 					Description: valueDescription.Description,
-					Value:       int(valueDescription.Value),
+					Value:       int64(valueDescription.Value),
 				})
 			}
 		case *dbc.AttributeValueForObjectDef:

--- a/pkg/canjson/encode.go
+++ b/pkg/canjson/encode.go
@@ -60,7 +60,7 @@ func (s *signal) setUnsignedValue(value uint64, desc *descriptor.Signal) {
 	s.Raw = uintToJSON(value)
 	s.Physical = floatToJSON(desc.ToPhysical(float64(value)))
 	s.Unit = desc.Unit
-	if value, ok := desc.ValueDescription(int(value)); ok {
+	if value, ok := desc.ValueDescription(int64(value)); ok {
 		s.Description = value
 	}
 }
@@ -69,7 +69,7 @@ func (s *signal) setSignedValue(value int64, desc *descriptor.Signal) {
 	s.Raw = intToJSON(value)
 	s.Physical = floatToJSON(desc.ToPhysical(float64(value)))
 	s.Unit = desc.Unit
-	if value, ok := desc.ValueDescription(int(value)); ok {
+	if value, ok := desc.ValueDescription(value); ok {
 		s.Description = value
 	}
 }
@@ -83,7 +83,7 @@ func (s *signal) setBoolValue(value bool, desc *descriptor.Signal) {
 		s.Physical = floatToJSON(desc.ToPhysical(0))
 	}
 	s.Unit = desc.Unit
-	intValue := 0
+	var intValue int64
 	if value {
 		intValue = 1
 	}

--- a/pkg/cantext/encode_test.go
+++ b/pkg/cantext/encode_test.go
@@ -122,15 +122,15 @@ func newDriverHeartbeatDescriptor() *descriptor.Message {
 				Description:      (string)(""),
 				ValueDescriptions: []*descriptor.ValueDescription{
 					{
-						Value:       (int)(0),
+						Value:       (int64)(0),
 						Description: (string)("None"),
 					},
 					{
-						Value:       (int)(1),
+						Value:       (int64)(1),
 						Description: (string)("Sync"),
 					},
 					{
-						Value:       (int)(2),
+						Value:       (int64)(2),
 						Description: (string)("Reboot"),
 					},
 				},

--- a/pkg/descriptor/signal.go
+++ b/pkg/descriptor/signal.go
@@ -45,7 +45,7 @@ type Signal struct {
 }
 
 // ValueDescription returns the value description for the provided value.
-func (s *Signal) ValueDescription(value int) (string, bool) {
+func (s *Signal) ValueDescription(value int64) (string, bool) {
 	for _, vd := range s.ValueDescriptions {
 		if vd.Value == value {
 			return vd.Description, true
@@ -122,11 +122,11 @@ func (s *Signal) UnmarshalValueDescription(d can.Data) (string, bool) {
 	if len(s.ValueDescriptions) == 0 {
 		return "", false
 	}
-	var intValue int
+	var intValue int64
 	if s.IsSigned {
-		intValue = int(s.UnmarshalSigned(d))
+		intValue = s.UnmarshalSigned(d)
 	} else {
-		intValue = int(s.UnmarshalUnsigned(d))
+		intValue = int64(s.UnmarshalUnsigned(d))
 	}
 	return s.ValueDescription(intValue)
 }

--- a/pkg/descriptor/valuedescription.go
+++ b/pkg/descriptor/valuedescription.go
@@ -1,6 +1,6 @@
 package descriptor
 
 type ValueDescription struct {
-	Value       int
+	Value       int64
 	Description string
 }

--- a/testdata/gen/go/example/example.dbc.go
+++ b/testdata/gen/go/example/example.dbc.go
@@ -2485,19 +2485,19 @@ var d = (*descriptor.Database)(&descriptor.Database{
 					Description:      (string)(""),
 					ValueDescriptions: ([]*descriptor.ValueDescription)([]*descriptor.ValueDescription{
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(0),
+							Value:       (int64)(0),
 							Description: (string)("None"),
 						}),
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(1),
+							Value:       (int64)(1),
 							Description: (string)("Sync"),
 						}),
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(2),
+							Value:       (int64)(2),
 							Description: (string)("Reboot"),
 						}),
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(3),
+							Value:       (int64)(3),
 							Description: (string)("Headlights On"),
 						}),
 					}),
@@ -2899,11 +2899,11 @@ var d = (*descriptor.Database)(&descriptor.Database{
 					Description:      (string)(""),
 					ValueDescriptions: ([]*descriptor.ValueDescription)([]*descriptor.ValueDescription{
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(1),
+							Value:       (int64)(1),
 							Description: (string)("One"),
 						}),
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(2),
+							Value:       (int64)(2),
 							Description: (string)("Two"),
 						}),
 					}),
@@ -2971,11 +2971,11 @@ var d = (*descriptor.Database)(&descriptor.Database{
 					Description:      (string)(""),
 					ValueDescriptions: ([]*descriptor.ValueDescription)([]*descriptor.ValueDescription{
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(0),
+							Value:       (int64)(0),
 							Description: (string)("Zero"),
 						}),
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(1),
+							Value:       (int64)(1),
 							Description: (string)("One"),
 						}),
 					}),
@@ -3001,19 +3001,19 @@ var d = (*descriptor.Database)(&descriptor.Database{
 					Description:      (string)(""),
 					ValueDescriptions: ([]*descriptor.ValueDescription)([]*descriptor.ValueDescription{
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(0),
+							Value:       (int64)(0),
 							Description: (string)("Zero"),
 						}),
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(1),
+							Value:       (int64)(1),
 							Description: (string)("Two"),
 						}),
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(2),
+							Value:       (int64)(2),
 							Description: (string)("Four"),
 						}),
 						(*descriptor.ValueDescription)(&descriptor.ValueDescription{
-							Value:       (int)(3),
+							Value:       (int64)(3),
 							Description: (string)("Six"),
 						}),
 					}),


### PR DESCRIPTION
Currently, 32 bit can signals with value table definied values that are greater than int32 max are not supported.
This change should allow for all 32 bit unsigned values to be supported as well as all 64 bit signed integer signal values.
