### PR TITLE
fix(ci): fetch git tags before running goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true
 
+      # Update tags for goreleaser to choose latest version
+      - name: Fetch tags
+        run: git fetch --force --tags
+
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v3.2.0
         with:


### PR DESCRIPTION
Otherwise goreleaser does not publish artifacts to the correct release.
