### PR TITLE
fix(generate): clean up go package name

### DIFF
--- a/internal/generate/file.go
+++ b/internal/generate/file.go
@@ -80,6 +80,10 @@ func Database(d *descriptor.Database) ([]byte, error) {
 
 func Package(f *File, d *descriptor.Database) {
 	packageName := strings.TrimSuffix(path.Base(d.SourceFile), path.Ext(d.SourceFile)) + "can"
+	// Remove illegal characters from package name
+	packageName = strings.ReplaceAll(packageName, ".", "")
+	packageName = strings.ReplaceAll(packageName, "-", "")
+	packageName = strings.ReplaceAll(packageName, "_", "")
 	f.P("// Package ", packageName, " provides primitives for encoding and decoding ", d.Name(), " CAN messages.")
 	f.P("//")
 	f.P("// Source: ", d.SourceFile)


### PR DESCRIPTION
This fixes issue where code generation on dbc files with name containing
dashes, underscores, and dots fails due to incorrectly generated package name.
