### PR TITLE
fix(candevice): add empty device struct for non-linux

### DIFF
--- a/pkg/candevice/device_others.go
+++ b/pkg/candevice/device_others.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 )
 
+type Device struct{}
+
 func New(_ string) (*Device, error) {
 	return nil, fmt.Errorf("candevice is not supported on OS %s and runtime %s", runtime.GOOS, runtime.Version())
 }


### PR DESCRIPTION
Fixes the following for non-linux host when running make:

```
[go-lint]
pkg/candevice/device_others.go:10:22: undeclared name: `Device` (typecheck)
func New(_ string) (*Device, error) {
^
[go-lint] exit status 1
[go-review] exit status 1
```
---

Awesome that other OSs are taken into consideration and the not supported error is returned. With this change, the error will now get propagated to the non-linux user when using the `candevice` package because the `Device` type will exist.