### PR TITLE
chore(candevice): add exported methods to enable LSP for non-linux users

### DIFF
--- a/pkg/candevice/device_others.go
+++ b/pkg/candevice/device_others.go
@@ -7,8 +7,40 @@ import (
 	"runtime"
 )
 
+type NotSupportedError struct{}
+
+func (e NotSupportedError) Error() string {
+	return fmt.Sprintf("candevice is not supported on OS %s and runtime %s", runtime.GOOS, runtime.Version())
+}
+
 type Device struct{}
 
 func New(_ string) (*Device, error) {
-	return nil, fmt.Errorf("candevice is not supported on OS %s and runtime %s", runtime.GOOS, runtime.Version())
+	return nil, NotSupportedError{}
+}
+
+func (d *Device) IsUp() (bool, error) {
+	return false, NotSupportedError{}
+}
+
+func (d *Device) SetUp() error {
+	return NotSupportedError{}
+}
+
+func (d *Device) SetDown() error {
+	return NotSupportedError{}
+}
+
+func (d *Device) Bitrate() (uint32, error) {
+	return 0, NotSupportedError{}
+}
+
+func (d *Device) SetBitrate(_ uint32) error {
+	return NotSupportedError{}
+}
+
+type Info struct{}
+
+func (d *Device) Info() (Info, error) {
+	return Info{}, NotSupportedError{}
 }


### PR DESCRIPTION
Primarily to improve the local development experience a little bit for non-linux users, i.e., a minimal working LSP autocomplete and a compilable program. WDYT?