### PR TITLE
chore(codeowners): transfer ownership to team-ads-platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @einride/team-aet-platform
+* @einride/team-ads-platform


### PR DESCRIPTION
aet-platform and aet-data has merged into this team.