### PR TITLE
Add support for virtual can

### DIFF
--- a/pkg/candevice/device_linux.go
+++ b/pkg/candevice/device_linux.go
@@ -12,7 +12,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const canLinkType = "can"
+const CanLinkType = "can"
+const VcanLinkType = "vcan"
 
 const (
 	StateErrorActive  = unix.CAN_STATE_ERROR_ACTIVE
@@ -146,7 +147,7 @@ func (d *Device) SetBitrate(bitrate uint32) error {
 	}
 
 	li := &linkInfoMsg{
-		linkType: canLinkType,
+		linkType: CanLinkType,
 	}
 	li.info.BitTiming.Bitrate = bitrate
 	ae := netlink.NewAttributeEncoder()
@@ -173,6 +174,7 @@ type Info struct {
 	Clock            Clock
 	CtrlMode         CtrlMode
 	BusErrorCounters BusErrorCounters
+	Type             string
 
 	State     uint32
 	RestartMs uint32
@@ -244,6 +246,7 @@ func (d *Device) unmarshalBinary(data []byte) error {
 			d.ifname = ad.String()
 		case unix.IFLA_LINKINFO:
 			ad.Nested(d.li.decode)
+			d.li.info.Type = d.li.linkType
 		default:
 		}
 	}
@@ -456,7 +459,7 @@ func (li *linkInfoMsg) decode(nad *netlink.AttributeDecoder) error {
 		switch nad.Type() {
 		case unix.IFLA_INFO_KIND:
 			li.linkType = nad.String()
-			if li.linkType != canLinkType {
+			if (li.linkType != CanLinkType) && (li.linkType != VcanLinkType) {
 				return fmt.Errorf("not a CAN interface")
 			}
 		case unix.IFLA_INFO_DATA:


### PR DESCRIPTION
I'm going to use it like that in an algorithm for auto-detecting CAN speed (I also need listen-only mode for that https://github.com/einride/can-go/pull/174):

    canInfo, err := d.Info()
    if err != nil {
            return err
    }

    if canInfo.Type == candevice.VcanLinkType {
            log.Println("Type is vcan, cancel auto-detecting CAN speed")
            return nil
    }

SetBitrate() and others don't have to changed, they will return `netlink receive: operation not supported` errors. Receive() and TransmitFrame() will continue working without any changes.

There are no tests, I thought I could add them to pkg/candevice/device_integration_test.go but nothing there uses vcan0 at this moment.
