### PR TITLE
fix(candevice): undefined type

### DIFF
--- a/pkg/candevice/device_linux.go
+++ b/pkg/candevice/device_linux.go
@@ -149,7 +149,7 @@ func (d *Device) SetListenOnlyMode(mode bool) error {
 	}
 
 	li := &linkInfoMsg{
-		linkType: canLinkType,
+		linkType: CanLinkType,
 	}
 
 	li.info, err = d.getCurrentParametersForSet()


### PR DESCRIPTION
The GitHub rebase wasn't all knowing and didn't account for a previous change.