### PR TITLE
Make compile public

### DIFF
--- a/cmd/cantool/main.go
+++ b/cmd/cantool/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/fatih/color"
 	"go.einride.tech/can/internal/generate"
+	"go.einride.tech/can/pkg/compile"
 	"go.einride.tech/can/pkg/dbc"
 	"go.einride.tech/can/pkg/dbc/analysis"
 	"go.einride.tech/can/pkg/dbc/analysis/passes/definitiontypeorder"
@@ -149,7 +150,7 @@ func genGo(inputFile, outputFile string) error {
 	if err != nil {
 		return err
 	}
-	result, err := generate.Compile(inputFile, input)
+	result, err := compile.Compile(inputFile, input)
 	if err != nil {
 		return err
 	}

--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -1,4 +1,4 @@
-package generate
+package compile
 
 import (
 	"fmt"

--- a/pkg/compile/compile_test.go
+++ b/pkg/compile/compile_test.go
@@ -1,4 +1,4 @@
-package generate
+package compile
 
 import (
 	"os"

--- a/pkg/compile/file_test.go
+++ b/pkg/compile/file_test.go
@@ -1,4 +1,4 @@
-package generate
+package compile
 
 import (
 	"os"


### PR DESCRIPTION
To be able to use the dbc file to decode messages, it must be parsed and its defs must be consolidated.
This is done in the internal `generate` package, so it can't be used by external programs.

This PR makes the compilation part a public package.