### PR TITLE
Add message ID whitelist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ func main() {
 It is possible to generate Go code from a `.dbc` file.
 
 ```
-$ go run go.einride.tech/can/cmd/cantool generate <dbc file root folder> <output folder>
+$ go run go.einride.tech/can/cmd/cantool generate <dbc file root folder> <output folder> [<white-listmessage-ids>...]
 ```
 
 In order to generate Go code that makes sense, we currently perform some

--- a/cmd/cantool/main.go
+++ b/cmd/cantool/main.go
@@ -51,6 +51,9 @@ func generateCommand(app *kingpin.Application) {
 		Arg("output-dir", "output directory").
 		Required().
 		String()
+	whiteList := command.
+		Arg("message-ids", "optional message-id whitelist").
+		Uint32List()
 	command.Action(func(c *kingpin.ParseContext) error {
 		return filepath.Walk(*inputDir, func(p string, i os.FileInfo, err error) error {
 			if err != nil {
@@ -65,7 +68,7 @@ func generateCommand(app *kingpin.Application) {
 			}
 			outputFile := relPath + ".go"
 			outputPath := filepath.Join(*outputDir, outputFile)
-			return genGo(p, outputPath)
+			return genGo(p, outputPath, *whiteList)
 		})
 	})
 }
@@ -141,7 +144,7 @@ func analyzers() []*analysis.Analyzer {
 	}
 }
 
-func genGo(inputFile, outputFile string) error {
+func genGo(inputFile, outputFile string, messageIds []uint32) error {
 	if err := os.MkdirAll(filepath.Dir(outputFile), 0o755); err != nil {
 		return err
 	}
@@ -149,7 +152,7 @@ func genGo(inputFile, outputFile string) error {
 	if err != nil {
 		return err
 	}
-	result, err := generate.Compile(inputFile, input)
+	result, err := generate.Compile(inputFile, input, generate.WithMessageIdWhiteList(messageIds))
 	if err != nil {
 		return err
 	}

--- a/internal/generate/compile.go
+++ b/internal/generate/compile.go
@@ -14,7 +14,9 @@ type CompileResult struct {
 	Warnings []error
 }
 
-func Compile(sourceFile string, data []byte) (result *CompileResult, err error) {
+type CompileOption func(*compiler)
+
+func Compile(sourceFile string, data []byte, options ...CompileOption) (result *CompileResult, err error) {
 	p := dbc.NewParser(sourceFile, data)
 	if err := p.Parse(); err != nil {
 		return nil, fmt.Errorf("failed to parse DBC source file: %w", err)
@@ -24,10 +26,28 @@ func Compile(sourceFile string, data []byte) (result *CompileResult, err error) 
 		db:   &descriptor.Database{SourceFile: sourceFile},
 		defs: defs,
 	}
+
+	for _, opt := range options {
+		opt(c)
+	}
+
 	c.collectDescriptors()
 	c.addMetadata()
 	c.sortDescriptors()
 	return &CompileResult{Database: c.db, Warnings: c.warnings}, nil
+}
+
+func WithMessageIdWhiteList(ids []uint32) CompileOption {
+	return func(c *compiler) {
+		if ids == nil {
+			return
+		}
+
+		c.onlyCompile = make([]dbc.MessageID, 0)
+		for _, id := range ids {
+			c.onlyCompile = append(c.onlyCompile, dbc.MessageID(id))
+		}
+	}
 }
 
 type compileError struct {
@@ -40,9 +60,10 @@ func (e *compileError) Error() string {
 }
 
 type compiler struct {
-	db       *descriptor.Database
-	defs     []dbc.Def
-	warnings []error
+	onlyCompile []dbc.MessageID
+	db          *descriptor.Database
+	defs        []dbc.Def
+	warnings    []error
 }
 
 func (c *compiler) addWarning(warning error) {
@@ -55,7 +76,7 @@ func (c *compiler) collectDescriptors() {
 		case *dbc.VersionDef:
 			c.db.Version = def.Version
 		case *dbc.MessageDef:
-			if def.MessageID == dbc.IndependentSignalsMessageID {
+			if c.skipCompile(def.MessageID) {
 				continue // don't compile
 			}
 			message := &descriptor.Message{
@@ -101,7 +122,7 @@ func (c *compiler) addMetadata() {
 		case *dbc.CommentDef:
 			switch def.ObjectType {
 			case dbc.ObjectTypeMessage:
-				if def.MessageID == dbc.IndependentSignalsMessageID {
+				if c.skipCompile(def.MessageID) {
 					continue // don't compile
 				}
 				message, ok := c.db.Message(def.MessageID.ToCAN())
@@ -111,7 +132,7 @@ func (c *compiler) addMetadata() {
 				}
 				message.Description = def.Comment
 			case dbc.ObjectTypeSignal:
-				if def.MessageID == dbc.IndependentSignalsMessageID {
+				if c.skipCompile(def.MessageID) {
 					continue // don't compile
 				}
 				signal, ok := c.db.Signal(def.MessageID.ToCAN(), string(def.SignalName))
@@ -129,7 +150,7 @@ func (c *compiler) addMetadata() {
 				node.Description = def.Comment
 			}
 		case *dbc.ValueDescriptionsDef:
-			if def.MessageID == dbc.IndependentSignalsMessageID {
+			if c.skipCompile(def.MessageID) {
 				continue // don't compile
 			}
 			if def.ObjectType != dbc.ObjectTypeSignal {
@@ -147,6 +168,9 @@ func (c *compiler) addMetadata() {
 				})
 			}
 		case *dbc.AttributeValueForObjectDef:
+			if c.skipCompile(def.MessageID) {
+				continue // don't compile
+			}
 			switch def.ObjectType {
 			case dbc.ObjectTypeMessage:
 				msg, ok := c.db.Message(def.MessageID.ToCAN())
@@ -169,8 +193,7 @@ func (c *compiler) addMetadata() {
 				sig, ok := c.db.Signal(def.MessageID.ToCAN(), string(def.SignalName))
 				if !ok {
 					c.addWarning(&compileError{def: def, reason: "no declared signal"})
-				}
-				if def.AttributeName == "GenSigStartValue" {
+				} else if def.AttributeName == "GenSigStartValue" {
 					sig.DefaultValue = int(def.IntValue)
 				}
 			}
@@ -204,4 +227,22 @@ func (c *compiler) sortDescriptors() {
 			})
 		}
 	}
+}
+
+func (c *compiler) skipCompile(id dbc.MessageID) bool {
+	if id == dbc.IndependentSignalsMessageID {
+		return true
+	}
+
+	if c.onlyCompile != nil {
+		for _, whiteListId := range c.onlyCompile {
+			if whiteListId == id {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
This PR adds an option for a message ID whitelist to only compile particular messages:

`generate <input-dir> <output-dir> [<message-ids>...]`

Example:
`generate dbcIn dbcOut 587 256`
