### PR TITLE
Add command to generate code for single DBC

### DIFF
--- a/cmd/cantool/main.go
+++ b/cmd/cantool/main.go
@@ -38,6 +38,7 @@ import (
 func main() {
 	app := kingpin.New("cantool", "CAN tool for Go programmers")
 	generateCommand(app)
+	generateSingleCommand(app)
 	lintCommand(app)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }
@@ -68,6 +69,29 @@ func generateCommand(app *kingpin.Application) {
 			outputPath := filepath.Join(*outputDir, outputFile)
 			return genGo(p, outputPath)
 		})
+	})
+}
+
+func generateSingleCommand(app *kingpin.Application) {
+	command := app.Command("generate-single", "generate CAN messages for single DBC file")
+	inputFile := command.
+		Arg("input-file", "input file").
+		Required().
+		ExistingFile()
+	outputFile := command.
+		Arg("output-file", "output file").
+		Required().
+		String()
+	command.Action(func(_ *kingpin.ParseContext) error {
+		outputPath := filepath.Clean(*outputFile)
+		inputPath := filepath.Clean(*inputFile)
+		if filepath.Ext(outputPath) != ".go" {
+			return errors.New("output file must have .go extension")
+		}
+		if filepath.Ext(inputPath) != ".dbc" {
+			return errors.New("input file must have .dbc extension")
+		}
+		return genGo(inputPath, outputPath)
 	})
 }
 


### PR DESCRIPTION
In some applications I am facing, some of the DBCs in the same directory are not needed to be generated and contain things that actually make the generation of go code crash (non standard or Einride compliant). I cannot change those DBCs that are non standard (since they are used elsewhere) but I also would like to kept them in that folder since they are used by other things (git submodule used by many other projects).

I propose this new command `generate-single` where you specify directly the DBC file and the output file. This gives more freedom to only generate for the desired DBC files without changing the existing `generate` command. It also allows to output each file to a different folder and even choose a different output name from the default if so desired by the user.