### PR TITLE
fix: bump Golang version to go1.20

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -1,5 +1,5 @@
 module go.einride.tech/can/.sage
 
-go 1.19
+go 1.20
 
 require go.einride.tech/sage v0.275.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.einride.tech/can
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
One of our dependencies requires Go 1.20, which means that the project is not compilable with Go 1.19. This commit updates the module files to demand the correct version.

This is not a breaking change since the repository was not buildable with Go 1.19 and thus we should not be breaking anything for anybody.