### PR TITLE
ci: remove deprecated goreview

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
+        with:
+          go-version: "~1.22"
 
       - name: Make
         run: make

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
+        with:
+          go-version: "~1.22"
 
       - name: Make
         run: make

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -12,7 +12,6 @@ import (
 	"go.einride.tech/sage/tools/sggo"
 	"go.einride.tech/sage/tools/sggolangcilint"
 	"go.einride.tech/sage/tools/sggolicenses"
-	"go.einride.tech/sage/tools/sggoreview"
 	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
 )
@@ -28,7 +27,7 @@ func main() {
 
 func Default(ctx context.Context) error {
 	sg.Deps(ctx, ConvcoCheck, FormatMarkdown, FormatYaml, GoGenerate, GenerateTestdata)
-	sg.Deps(ctx, GoLint, GoReview)
+	sg.Deps(ctx, GoLint)
 	sg.Deps(ctx, GoTest)
 	sg.Deps(ctx, GoModTidy)
 	sg.Deps(ctx, GoLicenses, GitVerifyNoDiff)
@@ -43,11 +42,6 @@ func GoModTidy(ctx context.Context) error {
 func GoTest(ctx context.Context) error {
 	sg.Logger(ctx).Println("running Go tests...")
 	return sggo.TestCommand(ctx).Run()
-}
-
-func GoReview(ctx context.Context) error {
-	sg.Logger(ctx).Println("reviewing Go files...")
-	return sggoreview.Run(ctx)
 }
 
 func GoLint(ctx context.Context) error {

--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,6 @@ go-lint: $(sagefile)
 go-mod-tidy: $(sagefile)
 	@$(sagefile) GoModTidy
 
-.PHONY: go-review
-go-review: $(sagefile)
-	@$(sagefile) GoReview
-
 .PHONY: go-test
 go-test: $(sagefile)
 	@$(sagefile) GoTest


### PR DESCRIPTION
To prevent breakage from the goreview repo being decommissioned.

All linting now done by GolangCI-Lint.
