### PR TITLE
feat: signal names capitalization

### DIFF
--- a/internal/generate/compile_test.go
+++ b/internal/generate/compile_test.go
@@ -323,6 +323,23 @@ func TestCompile_ExampleDBC(t *testing.T) {
 					},
 				},
 			},
+			{
+				ID:         700,
+				Name:       "SignalNameFormatting",
+				Length:     8,
+				SenderNode: "IO",
+				SendType:   descriptor.SendTypeNone,
+				Signals: []*descriptor.Signal{
+					{
+						Name:          "non_capitalized_signal",
+						Length:        8,
+						IsSigned:      true,
+						IsFloat:       false,
+						Scale:         1,
+						ReceiverNodes: []string{"DBG"},
+					},
+				},
+			},
 		},
 	}
 	input, err := os.ReadFile(exampleDBCFile)

--- a/internal/generate/example_test.go
+++ b/internal/generate/example_test.go
@@ -360,6 +360,13 @@ func TestExample_Node_CopyFromRx(_ *testing.T) {
 	_ = examplecan.NewMotorCommand().CopyFrom(motor.Rx().MotorCommand())
 }
 
+func TestExample_AccessToNonCapitalizedSignal(t *testing.T) {
+	// Ensures that the generated accessor for non-capitalized signal is accessible.
+	var expectedValue int8 = 42
+	m := examplecan.NewSignalNameFormatting().Setnon_capitalized_signal(expectedValue)
+	assert.Equal(t, expectedValue, m.Non_capitalized_signal())
+}
+
 func requireVCAN0(t *testing.T) {
 	t.Helper()
 	if _, err := net.InterfaceByName("vcan0"); err != nil {

--- a/testdata/dbc/example/example.dbc
+++ b/testdata/dbc/example/example.dbc
@@ -43,6 +43,9 @@ BO_ 600 IOFloat32: 8 IO
  SG_ Float32ValueNoRange : 0|32@1- (1,0) [0|0] "" DBG
  SG_ Float32WithRange : 32|32@1- (1,0) [-100|100] "" DBG
 
+BO_ 700 SignalNameFormatting: 8 IO
+ SG_ non_capitalized_signal : 0|8@1- (1,0) [0|0] "" DBG
+
 EV_ BrakeEngaged: 0 [0|1] "" 0 10 DUMMY_NODE_VECTOR0 Vector__XXX;
 EV_ Torque: 1 [0|30000] "mNm" 500 16 DUMMY_NODE_VECTOR0 Vector__XXX;
 

--- a/testdata/dbc/example/example.dbc.golden
+++ b/testdata/dbc/example/example.dbc.golden
@@ -1,4 +1,4 @@
-([]dbc.Def) (len=47) {
+([]dbc.Def) (len=48) {
  (*dbc.VersionDef)({
   Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:1:1,
   Version: (string) ""
@@ -531,8 +531,36 @@
    }
   }
  }),
- (*dbc.EnvironmentVariableDef)({
+ (*dbc.MessageDef)({
   Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:46:1,
+  MessageID: (dbc.MessageID) 700,
+  Name: (dbc.Identifier) (len=20) "SignalNameFormatting",
+  Size: (uint64) 8,
+  Transmitter: (dbc.Identifier) (len=2) "IO",
+  Signals: ([]dbc.SignalDef) (len=1) {
+   (dbc.SignalDef) {
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:47:2,
+    Name: (dbc.Identifier) (len=22) "non_capitalized_signal",
+    StartBit: (uint64) 0,
+    Size: (uint64) 8,
+    IsBigEndian: (bool) false,
+    IsSigned: (bool) true,
+    IsMultiplexerSwitch: (bool) false,
+    IsMultiplexed: (bool) false,
+    MultiplexerSwitch: (uint64) 0,
+    Offset: (float64) 0,
+    Factor: (float64) 1,
+    Minimum: (float64) 0,
+    Maximum: (float64) 0,
+    Unit: (string) "",
+    Receivers: ([]dbc.Identifier) (len=1) {
+     (dbc.Identifier) (len=3) "DBG"
+    }
+   }
+  }
+ }),
+ (*dbc.EnvironmentVariableDef)({
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:49:1,
   Name: (dbc.Identifier) (len=12) "BrakeEngaged",
   Type: (dbc.EnvironmentVariableType) 0,
   Minimum: (float64) 0,
@@ -546,7 +574,7 @@
   }
  }),
  (*dbc.EnvironmentVariableDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:47:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:50:1,
   Name: (dbc.Identifier) (len=6) "Torque",
   Type: (dbc.EnvironmentVariableType) 1,
   Minimum: (float64) 0,
@@ -560,7 +588,7 @@
   }
  }),
  (*dbc.CommentDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:49:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:52:1,
   ObjectType: (dbc.ObjectType) (len=3) "EV_",
   NodeName: (dbc.Identifier) "",
   MessageID: (dbc.MessageID) 0,
@@ -569,7 +597,7 @@
   Comment: (string) (len=19) "Brake fully engaged"
  }),
  (*dbc.CommentDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:50:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:53:1,
   ObjectType: (dbc.ObjectType) (len=3) "BU_",
   NodeName: (dbc.Identifier) (len=6) "DRIVER",
   MessageID: (dbc.MessageID) 0,
@@ -578,7 +606,7 @@
   Comment: (string) (len=37) "The driver controller driving the car"
  }),
  (*dbc.CommentDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:51:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:54:1,
   ObjectType: (dbc.ObjectType) (len=3) "BU_",
   NodeName: (dbc.Identifier) (len=5) "MOTOR",
   MessageID: (dbc.MessageID) 0,
@@ -587,7 +615,7 @@
   Comment: (string) (len=31) "The motor controller of the car"
  }),
  (*dbc.CommentDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:52:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:55:1,
   ObjectType: (dbc.ObjectType) (len=3) "BU_",
   NodeName: (dbc.Identifier) (len=6) "SENSOR",
   MessageID: (dbc.MessageID) 0,
@@ -596,7 +624,7 @@
   Comment: (string) (len=32) "The sensor controller of the car"
  }),
  (*dbc.CommentDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:53:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:56:1,
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
   NodeName: (dbc.Identifier) "",
   MessageID: (dbc.MessageID) 100,
@@ -605,7 +633,7 @@
   Comment: (string) (len=48) "Sync message used to synchronize the controllers"
  }),
  (*dbc.AttributeDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:55:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:58:1,
   ObjectType: (dbc.ObjectType) "",
   Name: (dbc.Identifier) (len=7) "BusType",
   Type: (dbc.AttributeValueType) (len=6) "STRING",
@@ -616,7 +644,7 @@
   EnumValues: ([]string) <nil>
  }),
  (*dbc.AttributeDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:56:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:59:1,
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
   Name: (dbc.Identifier) (len=14) "GenMsgSendType",
   Type: (dbc.AttributeValueType) (len=4) "ENUM",
@@ -631,7 +659,7 @@
   }
  }),
  (*dbc.AttributeDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:57:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:60:1,
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
   Name: (dbc.Identifier) (len=15) "GenMsgCycleTime",
   Type: (dbc.AttributeValueType) (len=3) "INT",
@@ -642,7 +670,7 @@
   EnumValues: ([]string) <nil>
  }),
  (*dbc.AttributeDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:58:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:61:1,
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   Name: (dbc.Identifier) (len=9) "FieldType",
   Type: (dbc.AttributeValueType) (len=6) "STRING",
@@ -653,7 +681,7 @@
   EnumValues: ([]string) <nil>
  }),
  (*dbc.AttributeDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:59:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:62:1,
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   Name: (dbc.Identifier) (len=16) "GenSigStartValue",
   Type: (dbc.AttributeValueType) (len=3) "INT",
@@ -664,7 +692,7 @@
   EnumValues: ([]string) <nil>
  }),
  (*dbc.AttributeDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:60:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:63:1,
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   Name: (dbc.Identifier) (len=3) "SPN",
   Type: (dbc.AttributeValueType) (len=3) "INT",
@@ -675,35 +703,35 @@
   EnumValues: ([]string) <nil>
  }),
  (*dbc.AttributeDefaultValueDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:61:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:64:1,
   AttributeName: (dbc.Identifier) (len=7) "BusType",
   DefaultIntValue: (int64) 0,
   DefaultFloatValue: (float64) 0,
   DefaultStringValue: (string) (len=3) "CAN"
  }),
  (*dbc.AttributeDefaultValueDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:62:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:65:1,
   AttributeName: (dbc.Identifier) (len=9) "FieldType",
   DefaultIntValue: (int64) 0,
   DefaultFloatValue: (float64) 0,
   DefaultStringValue: (string) ""
  }),
  (*dbc.AttributeDefaultValueDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:63:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:66:1,
   AttributeName: (dbc.Identifier) (len=15) "GenMsgCycleTime",
   DefaultIntValue: (int64) 0,
   DefaultFloatValue: (float64) 0,
   DefaultStringValue: (string) ""
  }),
  (*dbc.AttributeDefaultValueDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:64:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:67:1,
   AttributeName: (dbc.Identifier) (len=16) "GenSigStartValue",
   DefaultIntValue: (int64) 0,
   DefaultFloatValue: (float64) 0,
   DefaultStringValue: (string) ""
  }),
  (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:66:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:69:1,
   AttributeName: (dbc.Identifier) (len=14) "GenMsgSendType",
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
   MessageID: (dbc.MessageID) 1,
@@ -715,7 +743,7 @@
   StringValue: (string) (len=4) "None"
  }),
  (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:67:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:70:1,
   AttributeName: (dbc.Identifier) (len=14) "GenMsgSendType",
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
   MessageID: (dbc.MessageID) 100,
@@ -727,7 +755,7 @@
   StringValue: (string) (len=6) "Cyclic"
  }),
  (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:68:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:71:1,
   AttributeName: (dbc.Identifier) (len=15) "GenMsgCycleTime",
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
   MessageID: (dbc.MessageID) 100,
@@ -739,55 +767,55 @@
   StringValue: (string) ""
  }),
  (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:69:1,
-  AttributeName: (dbc.Identifier) (len=14) "GenMsgSendType",
-  ObjectType: (dbc.ObjectType) (len=3) "BO_",
-  MessageID: (dbc.MessageID) 101,
-  SignalName: (dbc.Identifier) "",
-  NodeName: (dbc.Identifier) "",
-  EnvironmentVariableName: (dbc.Identifier) "",
-  IntValue: (int64) 0,
-  FloatValue: (float64) 0,
-  StringValue: (string) (len=6) "Cyclic"
- }),
- (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:70:1,
-  AttributeName: (dbc.Identifier) (len=15) "GenMsgCycleTime",
-  ObjectType: (dbc.ObjectType) (len=3) "BO_",
-  MessageID: (dbc.MessageID) 101,
-  SignalName: (dbc.Identifier) "",
-  NodeName: (dbc.Identifier) "",
-  EnvironmentVariableName: (dbc.Identifier) "",
-  IntValue: (int64) 100,
-  FloatValue: (float64) 0,
-  StringValue: (string) ""
- }),
- (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:71:1,
-  AttributeName: (dbc.Identifier) (len=14) "GenMsgSendType",
-  ObjectType: (dbc.ObjectType) (len=3) "BO_",
-  MessageID: (dbc.MessageID) 200,
-  SignalName: (dbc.Identifier) "",
-  NodeName: (dbc.Identifier) "",
-  EnvironmentVariableName: (dbc.Identifier) "",
-  IntValue: (int64) 0,
-  FloatValue: (float64) 0,
-  StringValue: (string) (len=6) "Cyclic"
- }),
- (*dbc.AttributeValueForObjectDef)({
   Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:72:1,
-  AttributeName: (dbc.Identifier) (len=15) "GenMsgCycleTime",
+  AttributeName: (dbc.Identifier) (len=14) "GenMsgSendType",
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
-  MessageID: (dbc.MessageID) 200,
+  MessageID: (dbc.MessageID) 101,
   SignalName: (dbc.Identifier) "",
   NodeName: (dbc.Identifier) "",
   EnvironmentVariableName: (dbc.Identifier) "",
-  IntValue: (int64) 100,
+  IntValue: (int64) 0,
   FloatValue: (float64) 0,
-  StringValue: (string) ""
+  StringValue: (string) (len=6) "Cyclic"
  }),
  (*dbc.AttributeValueForObjectDef)({
   Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:73:1,
+  AttributeName: (dbc.Identifier) (len=15) "GenMsgCycleTime",
+  ObjectType: (dbc.ObjectType) (len=3) "BO_",
+  MessageID: (dbc.MessageID) 101,
+  SignalName: (dbc.Identifier) "",
+  NodeName: (dbc.Identifier) "",
+  EnvironmentVariableName: (dbc.Identifier) "",
+  IntValue: (int64) 100,
+  FloatValue: (float64) 0,
+  StringValue: (string) ""
+ }),
+ (*dbc.AttributeValueForObjectDef)({
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:74:1,
+  AttributeName: (dbc.Identifier) (len=14) "GenMsgSendType",
+  ObjectType: (dbc.ObjectType) (len=3) "BO_",
+  MessageID: (dbc.MessageID) 200,
+  SignalName: (dbc.Identifier) "",
+  NodeName: (dbc.Identifier) "",
+  EnvironmentVariableName: (dbc.Identifier) "",
+  IntValue: (int64) 0,
+  FloatValue: (float64) 0,
+  StringValue: (string) (len=6) "Cyclic"
+ }),
+ (*dbc.AttributeValueForObjectDef)({
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:75:1,
+  AttributeName: (dbc.Identifier) (len=15) "GenMsgCycleTime",
+  ObjectType: (dbc.ObjectType) (len=3) "BO_",
+  MessageID: (dbc.MessageID) 200,
+  SignalName: (dbc.Identifier) "",
+  NodeName: (dbc.Identifier) "",
+  EnvironmentVariableName: (dbc.Identifier) "",
+  IntValue: (int64) 100,
+  FloatValue: (float64) 0,
+  StringValue: (string) ""
+ }),
+ (*dbc.AttributeValueForObjectDef)({
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:76:1,
   AttributeName: (dbc.Identifier) (len=14) "GenMsgSendType",
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
   MessageID: (dbc.MessageID) 400,
@@ -799,7 +827,7 @@
   StringValue: (string) (len=6) "Cyclic"
  }),
  (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:74:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:77:1,
   AttributeName: (dbc.Identifier) (len=15) "GenMsgCycleTime",
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
   MessageID: (dbc.MessageID) 400,
@@ -811,7 +839,7 @@
   StringValue: (string) ""
  }),
  (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:75:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:78:1,
   AttributeName: (dbc.Identifier) (len=14) "GenMsgSendType",
   ObjectType: (dbc.ObjectType) (len=3) "BO_",
   MessageID: (dbc.MessageID) 500,
@@ -823,7 +851,7 @@
   StringValue: (string) (len=7) "OnEvent"
  }),
  (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:76:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:79:1,
   AttributeName: (dbc.Identifier) (len=9) "FieldType",
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   MessageID: (dbc.MessageID) 100,
@@ -835,7 +863,7 @@
   StringValue: (string) (len=7) "Command"
  }),
  (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:77:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:80:1,
   AttributeName: (dbc.Identifier) (len=9) "FieldType",
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   MessageID: (dbc.MessageID) 500,
@@ -847,7 +875,7 @@
   StringValue: (string) (len=8) "TestEnum"
  }),
  (*dbc.AttributeValueForObjectDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:78:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:81:1,
   AttributeName: (dbc.Identifier) (len=16) "GenSigStartValue",
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   MessageID: (dbc.MessageID) 500,
@@ -859,109 +887,109 @@
   StringValue: (string) ""
  }),
  (*dbc.ValueDescriptionsDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:80:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:83:1,
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   MessageID: (dbc.MessageID) 100,
   SignalName: (dbc.Identifier) (len=7) "Command",
   EnvironmentVariableName: (dbc.Identifier) "",
   ValueDescriptions: ([]dbc.ValueDescriptionDef) (len=4) {
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:80:18,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:83:18,
     Value: (float64) 3,
     Description: (string) (len=13) "Headlights On"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:80:36,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:83:36,
     Value: (float64) 2,
     Description: (string) (len=6) "Reboot"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:80:47,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:83:47,
     Value: (float64) 1,
     Description: (string) (len=4) "Sync"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:80:56,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:83:56,
     Value: (float64) 0,
     Description: (string) (len=4) "None"
    }
   }
  }),
  (*dbc.ValueDescriptionsDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:81:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:84:1,
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   MessageID: (dbc.MessageID) 500,
   SignalName: (dbc.Identifier) (len=8) "TestEnum",
   EnvironmentVariableName: (dbc.Identifier) "",
   ValueDescriptions: ([]dbc.ValueDescriptionDef) (len=2) {
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:81:19,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:84:19,
     Value: (float64) 2,
     Description: (string) (len=3) "Two"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:81:27,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:84:27,
     Value: (float64) 1,
     Description: (string) (len=3) "One"
    }
   }
  }),
  (*dbc.ValueDescriptionsDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:82:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:85:1,
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   MessageID: (dbc.MessageID) 500,
   SignalName: (dbc.Identifier) (len=14) "TestScaledEnum",
   EnvironmentVariableName: (dbc.Identifier) "",
   ValueDescriptions: ([]dbc.ValueDescriptionDef) (len=4) {
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:82:25,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:85:25,
     Value: (float64) 3,
     Description: (string) (len=3) "Six"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:82:33,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:85:33,
     Value: (float64) 2,
     Description: (string) (len=4) "Four"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:82:42,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:85:42,
     Value: (float64) 1,
     Description: (string) (len=3) "Two"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:82:50,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:85:50,
     Value: (float64) 0,
     Description: (string) (len=4) "Zero"
    }
   }
  }),
  (*dbc.ValueDescriptionsDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:83:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:86:1,
   ObjectType: (dbc.ObjectType) (len=3) "SG_",
   MessageID: (dbc.MessageID) 500,
   SignalName: (dbc.Identifier) (len=12) "TestBoolEnum",
   EnvironmentVariableName: (dbc.Identifier) "",
   ValueDescriptions: ([]dbc.ValueDescriptionDef) (len=2) {
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:83:23,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:86:23,
     Value: (float64) 1,
     Description: (string) (len=3) "One"
    },
    (dbc.ValueDescriptionDef) {
-    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:83:31,
+    Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:86:31,
     Value: (float64) 0,
     Description: (string) (len=4) "Zero"
    }
   }
  }),
  (*dbc.SignalValueTypeDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:85:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:88:1,
   MessageID: (dbc.MessageID) 600,
   SignalName: (dbc.Identifier) (len=19) "Float32ValueNoRange",
   SignalValueType: (dbc.SignalValueType) 1
  }),
  (*dbc.SignalValueTypeDef)({
-  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:86:1,
+  Pos: (scanner.Position) ../../testdata/dbc/example/example.dbc:89:1,
   MessageID: (dbc.MessageID) 600,
   SignalName: (dbc.Identifier) (len=16) "Float32WithRange",
   SignalValueType: (dbc.SignalValueType) 1


### PR DESCRIPTION
Capitalize signal names in the generated code to make access functions for signals with snake_case names visible.

Reasoning:
Some DBC files may contain snake_case signal name. For example for the next message:
```
BO_ 42 ActuatorGetPosition: 4 FCAL
 SG_ get_position : 0|32@1- (1,0) [-400.0|400.0] "rad" FCU
```
The next signal access method will be generated, which leads to inaccessibility of the signal:
```
func (m *ActuatorGetPosition) get_position() float64 {
	...
}
```

I implemented a simple solution in this PR. If you want to use more general approach in this case, we can discuss necessary changes