### PR TITLE
feat: add socketcan option to filter received frames by CAN ID

### DIFF
--- a/pkg/socketcan/dial.go
+++ b/pkg/socketcan/dial.go
@@ -9,6 +9,14 @@ const udp = "udp"
 
 type DialOption func(*dialOpts)
 
+// IDFilter matches a frame when `frame.ID & filter.Mask == filter.ID & filter.Mask`
+type IDFilter struct {
+	ID   uint32
+	Mask uint32
+	// Set flag to filter out matching frames rather than include them
+	Exclude bool
+}
+
 // Dial connects to the address on the named net.
 //
 // Linux only: If net is "can" it creates a SocketCAN connection to the device

--- a/pkg/socketcan/dialraw_others.go
+++ b/pkg/socketcan/dialraw_others.go
@@ -19,3 +19,8 @@ func WithReceiveErrorFrames() DialOption {
 	return func(o *dialOpts) {
 	}
 }
+
+func WithFilterReceivedFramesByID(filters []IDFilter) DialOption {
+	return func(o *dialOpts) {
+	}
+}


### PR DESCRIPTION
Hi,

I needed to filter received frames by CAN ID so I've added a `WithFilterReceivedFramesByID()` option for socketcan Dial.
Thought it might be more generally useful. Let me know what you think.

Sam

---

Provides received frame filtering by ID using the CAN_RAW_FILTER socket option on Linux
See https://docs.kernel.org/networking/can.html#raw-socket-option-can-raw-filter

This is useful when there are multiple devices on the CAN bus and you don't want to dedicate a goroutine to reading and throwing away frames from devices that you're not interested in just so the receive buffer doesn't fill up.