### PR TITLE
feat: support vxcan with candevice

### DIFF
--- a/pkg/candevice/device_linux.go
+++ b/pkg/candevice/device_linux.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	CanLinkType  = "can"
-	VcanLinkType = "vcan"
+	CanLinkType   = "can"
+	VcanLinkType  = "vcan"
+	VxcanLinkType = "vxcan"
 )
 
 const (
@@ -545,7 +546,7 @@ func (li *linkInfoMsg) decode(nad *netlink.AttributeDecoder) error {
 		switch nad.Type() {
 		case unix.IFLA_INFO_KIND:
 			li.linkType = nad.String()
-			if (li.linkType != CanLinkType) && (li.linkType != VcanLinkType) {
+			if (li.linkType != CanLinkType) && (li.linkType != VcanLinkType) && (li.linkType != VxcanLinkType) {
 				return fmt.Errorf("not a CAN interface")
 			}
 		case unix.IFLA_INFO_DATA:


### PR DESCRIPTION
I'm using VXCAN to tunnel CAN to my Go application running in a Docker container, and needed to add an exception for "vxcan" link types to the "is it CAN" check.

From the Linux Kconfig documentation:
```
Similar to the virtual ethernet driver veth, vxcan implements a
local CAN traffic tunnel between two virtual CAN network devices.
When creating a vxcan, two vxcan devices are created as pair.
When one end receives the packet it appears on its pair and vice
versa. The vxcan can be used for cross namespace communication.

In opposite to vcan loopback devices the vxcan only forwards CAN
frames to its pair and does *not* provide a local echo of sent
CAN frames. To disable a potential echo in af_can.c the vxcan driver
announces IFF_ECHO in the interface flags. To have a clean start
in each namespace the CAN GW hop counter is set to zero.

This driver can also be built as a module. If so, the module
will be called vxcan. 
```

---

Only the type check needs to be updated to allow the candevice module to support VXCAN devices.